### PR TITLE
Upgrade to version 4.0.1 of JGit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <org.eclipse.equinox.common.version>3.6.200.v20130402-1505</org.eclipse.equinox.common.version>
         <org.eclipse.jdt.core.version>3.10.0.v20140604-1726</org.eclipse.jdt.core.version>
         <org.eclipse.jetty.version>9.3.1.v20150714</org.eclipse.jetty.version>
-        <org.eclipse.jgit.version>2.3.1.201302201838-r</org.eclipse.jgit.version>
+        <org.eclipse.jgit.version>4.0.1.201506240215-r</org.eclipse.jgit.version>
         <org.eclipse.osgi.version>3.10.0.v20140606-1445</org.eclipse.osgi.version>
         <org.eclipse.text.version>3.5.101</org.eclipse.text.version>
         <org.everrest.assured.version>${org.everrest.version}</org.everrest.assured.version>


### PR DESCRIPTION
Move from version 2.3 to version 3.7.1 of JGit as a preparation for integrating JGit into the Git Extension of Che.

Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>