### PR TITLE
Fix UnsatisfiedLinkError when loading UnixProcessManager with OpenJDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <maven.invoker.version>2.1.1</maven.invoker.version>
         <maven.plugin-annotations.version>3.2</maven.plugin-annotations.version>
         <maven.plugin-api.version>2.0</maven.plugin-api.version>
-        <net.java.dev.jna.version>3.5.2</net.java.dev.jna.version>
+        <net.java.dev.jna.version>4.1.0</net.java.dev.jna.version>
         <net.sf.opencsv.version>2.3</net.sf.opencsv.version>
         <net.sourceforge.schemacrawler.version>10.09.01</net.sourceforge.schemacrawler.version>
         <org.antlr.version>3.4</org.antlr.version>


### PR DESCRIPTION
The following exception occurs with the older version of net.java.dev.jna when running with OpenJDK

java.lang.UnsatisfiedLinkError: Can't obtain static newInstance method for class com.sun.jna.Structure
         at com.sun.jna.Native.initIDs(Native Method)
         at com.sun.jna.Native.<clinit>(Native.java:137)
         at org.eclipse.che.api.core.util.UnixProcessManager.<clinit>(UnixProcessManager.java:46)