### PR TITLE
Remove an exclusion of commons-loggin:commons-logging dependency for jayway.restassured:rest-assured dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,12 +340,6 @@
                 <groupId>com.jayway.restassured</groupId>
                 <artifactId>rest-assured</artifactId>
                 <version>${com.jayway.restassured.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-logging</artifactId>
-                        <groupId>commons-logging</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.jcraft</groupId>


### PR DESCRIPTION
This pull request need for down port the HttpJsonRequest ( https://github.com/codenvy/che-core/pull/558 ) 